### PR TITLE
Improved example.py

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,4 +1,8 @@
 """Find all months in a given year and count the crimes.
+
+   This is useful when submitting a list of file names if
+   a regex expression will not get you all the files you want.
+
    run as spark-submit example.py
 """
 
@@ -17,6 +21,7 @@ def concat_all_dataframes(*args):
 place = 'west-yorkshire'
 year = '2016'
 
+# get a list of filenames that will be concatenated into a single frame
 # the format has the 0 character before single numbers. 
 # At the moment we don't have all months for 2016 in /data/ukpolice
 months = ('01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11')

--- a/example.py
+++ b/example.py
@@ -1,20 +1,31 @@
-
-"""Concatenate two dataframes in pyspark. 
-   run as spark-submit concat_pyspark.py --py-files
+"""Find all months in a given year and count the crimes.
+   run as spark-submit example.py
 """
 
 from __future__ import print_function
+from functools import reduce
 import pyspark
 from pyspark import SparkContext
-from pyspark.sql import SQLContext
-logFile = "README.md"  # Should be some file on your system
+from pyspark.sql import SQLContext, DataFrame
 sc = SparkContext("local", "pyspark")
 sqlContext = SQLContext(sc)
-logData = sc.textFile(logFile).cache()
 
-file_names = ['2010-12-{place}-street.csv'.format(place=p) for p in ('west-yorkshire', 'wiltshire')]
-data_directory = '/data/ukpolice/2010-12'
-wy_df = sqlContext.read.format('com.databricks.spark.csv').options(header='true', inferschema='true').load('{}/{}'.format(data_directory, file_names[0]))
-wi_df = sqlContext.read.format('com.databricks.spark.csv').options(header='true', inferschema='true').load('{}/{}'.format(data_directory, file_names[1]))
-unified_df = wy_df.unionAll(wi_df)
-print(unified_df.show())
+def concat_all_dataframes(*args):
+    """Concatenate all the dataframes given as input."""
+    return reduce(DataFrame.unionAll, args)
+
+place = 'west-yorkshire'
+year = '2016'
+
+# the format has the 0 character before single numbers. 
+# At the moment we don't have all months for 2016 in /data/ukpolice
+months = ('01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11')
+file_names = ['/data/ukpolice/{year}-{month}/{year}-{month}-{place}-street.csv'.format(year=year,
+                                                                                       month=m,
+                                                                                       place=place) for m in months]
+
+# load dataframes as a generator
+annual_dataframes = (sqlContext.read.format('com.databricks.spark.csv').options(header='true', inferschema='true').load(month)
+                     for month in file_names)
+annual_crimes = concat_all_dataframes(*annual_dataframes)
+print(annual_crimes.groupby('Month').count().show())


### PR DESCRIPTION
Altered the example to take a list of csv files in the case that a simple regex expansion isn't sufficient, concat all the dataframes using a custom concatenate function, and print some groupby count transformation.